### PR TITLE
Copy public folder on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
+RUN if [ -d "/app/public" ]; then cp -r /app/public ./public; fi # Copy public folder if it exists
 
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
Hello,

Using this template on existing project generated som issues on images. This happened because Dockerfile on Stage 3 does not copy the public folder, if it exists.

Just added a single line to copy the `public` folder if it exists.